### PR TITLE
Check rawData-Type before parsing

### DIFF
--- a/grant-manager.js
+++ b/grant-manager.js
@@ -304,7 +304,13 @@ GrantManager.prototype.validateAccessToken = function(token, callback) {
  */
 GrantManager.prototype.createGrant = function(rawData) {
 
-  var grantData = JSON.parse( rawData );
+  var grantData;
+  
+  if( typeof rawData === 'string' ){
+    grantData = JSON.parse( rawData );
+  } else {
+    grantData = rawData;
+  }
 
   var access_token;
   var refresh_token;


### PR DESCRIPTION
Check if received data from Keycloak/Client needs to be parsed to avoid unexpected token error.

Somehow using the keycloak-nodejs-adapter as bearer-only with keycloak-1.7.0.Final, Keycloak.createGrant(rawData) gets passed the Parameters as a normal Javascript-Object. Hence JSON.parse(rawData) fails and produces error "unexpected token o".
